### PR TITLE
Name concept of early refuting a match

### DIFF
--- a/lib/action_state.rb
+++ b/lib/action_state.rb
@@ -10,7 +10,7 @@ module ActionState
       scope(name, Proc.new(&block))
 
       define_method("#{name}?") do |*args, **kwargs|
-        Predicate.new(self).instance_exec(*args, **kwargs, &block).result
+        Predicate.new(self).instance_exec(*args, **kwargs, &block).__matched__
       end
     end
   end

--- a/lib/action_state/predicate.rb
+++ b/lib/action_state/predicate.rb
@@ -1,49 +1,40 @@
 module ActionState
   class Predicate
-    attr_reader :result
-
     def initialize(record)
       @record = record
-      @result = true
+      @match_refuted = false
+    end
+
+    def __matched__
+      !@match_refuted
     end
 
     def excluding(*records)
-      return self unless result
-
-      @result = false if records.include?(@record)
-
+      @match_refuted ||= records.include?(@record)
       self
     end
 
     def where(**kwargs)
-      return self unless @result
-
-      @result = false if kwargs.any? { |k, v| !compare(v, @record.send(k)) }
-
+      @match_refuted ||= kwargs.any? { |k, v| !compare(v, @record.send(k)) }
       self
     end
 
     def not(**kwargs)
-      return self unless @result
-
-      @result = false if kwargs.any? do |k, v|
-        attribute = @record.send(k)
-        next true if attribute.nil? && !v.nil?
-        compare(v, attribute)
-      end
-
+      @match_refuted ||= kwargs.any? { |k, v| compare_with_nil_difference(v, @record.send(k)) }
       self
     end
 
     def method_missing(method_name, *args, **kwargs, &block)
-      return self unless @result
-
-      @result = false unless @record.send("#{method_name}?", *args, **kwargs, &block)
-
+      @match_refuted ||= !@record.send("#{method_name}?", *args, **kwargs, &block)
       self
     end
 
     private
+
+    def compare_with_nil_difference(value, attribute_value)
+      return true if attribute_value.nil? && !value.nil?
+      compare(value, attribute_value)
+    end
 
     def compare(value, attribute_value)
       case value


### PR DESCRIPTION
@joeldrapper I was curious to try out a version of https://github.com/joeldrapper/action_state/pull/2#issuecomment-1065124508 and the concept I've hit on here is to encapsulate the matching check in `matched?` which returns true if we haven't refuted the match early.

Though `matched?` could potentially clash with another Active Record model predicate name, it could be renamed to `__matched__`.

What do you think?